### PR TITLE
Use android.json instead of config.xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "name": "cordova-google-api-version",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Cordova plugin to solve Google API version conflicts by pining a desired version for all Google APIs (eg: play-services, firebase)",
   "author": "Chris Scott, Transistor Software",
   "license": "MIT",
-  "dependencies": {
-  	"xml2js": "~0.4.19"
-  },
+  "dependencies": {},
   "devDependencies": {}
 }


### PR DESCRIPTION
Can't use config.xml if someone adds plugins with plugman as it won't save plugin states to config.xml.

I also didn't like the method to parse the whole config.xml just to find the plugin itself then simply pop the variable. I don't really know if someone ever need to add another variable to this plugin, but if that is the case the old method will break immediately, or at least depends on the order of variables.

Tested with cordova-android@6.3.0 and cordova-android@7.1.0